### PR TITLE
Allow clicking checklist section titles to expand/collapse sections

### DIFF
--- a/C++_Basics.html
+++ b/C++_Basics.html
@@ -31,26 +31,40 @@
     <h2>C++ Basics</h2>
     <ul>
       <li class="checklist-item">
-        <label>
-          <input type="checkbox" class="checkbox" data-checklist="cpp-basics">
-          <span class="checkmark"></span>
-          Introduction to C++
-          <span class="dropdown-arrow"></span>
-          <!-- Add the drop-down arrow icon -->
-        </label>
+        <div class="section">
+          <div class="section-box">
+            <label class="section-box-label">
+              <input type="checkbox" class="checkbox" data-checklist="cpp-basics">
+              <span class="checkmark"></span>
+            </label>
+          </div>
+          <div class="section-title">
+            <label class="section-title-label">
+              Introduction to C++
+              <span class="dropdown-arrow"></span>
+            </label>
+          </div>
+        </div>
         <div class="hidden-text">
           <!-- Hidden content for the drop-down menu -->
           C++ is a powerful programming language. It is an extension of the C language and provides object-oriented features. This topic introduces you to the basics of C++ and its importance in modern programming.
         </div>
       </li>
       <li class="checklist-item">
-        <label>
-          <input type="checkbox" class="checkbox" data-checklist="cpp-basics">
-          <span class="checkmark"></span>
-          Variables and Data Types
-          <span class="dropdown-arrow"></span>
-          <!-- Add the drop-down arrow icon -->
-        </label>
+        <div class="section">
+          <div class="section-box">
+            <label class="section-box-label">
+              <input type="checkbox" class="checkbox" data-checklist="cpp-basics">
+              <span class="checkmark"></span>
+            </label>
+          </div>
+          <div class="section-title">
+            <label class="section-title-label">
+              Variables and Data Types
+              <span class="dropdown-arrow"></span>
+            </label>
+          </div>
+        </div>
         <div class="hidden-text">
           <!-- Hidden content for the drop-down menu -->
           Learn about variables and different data types in C++. Variables are used to store values in memory. Understanding data types is essential for efficient memory management and creating robust programs.

--- a/OOP.html
+++ b/OOP.html
@@ -31,39 +31,60 @@
       <h2>Object-Oriented Programming (OOP) in C++</h2>
       <ul>
         <li class="checklist-item">
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-            <span class="checkmark"></span>
-            What is OOP?
-            <span class="dropdown-arrow"></span>
-            <!-- Add the drop-down arrow icon -->
-          </label>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                What is OOP?
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
           <div class="hidden-text">
             <!-- Hidden content for the drop-down menu -->
             Object-Oriented Programming (OOP) is a programming paradigm that focuses on organizing code into objects, which are instances of classes. It emphasizes concepts such as encapsulation, inheritance, and polymorphism to create modular and reusable code.
           </div>
         </li>
         <li class="checklist-item">
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-            <span class="checkmark"></span>
-            Classes and Objects
-            <span class="dropdown-arrow"></span>
-            <!-- Add the drop-down arrow icon -->
-          </label>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Classes and Objects
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
           <div class="hidden-text">
             <!-- Hidden content for the drop-down menu -->
             Classes are user-defined data types in C++ that encapsulate data and functions. Objects are instances of classes. Learn how to create classes, define member functions, and access class members using objects.
           </div>
         </li>
         <li class="checklist-item">
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-            <span class="checkmark"></span>
-            Constructors and Destructors
-            <span class="dropdown-arrow"></span>
-            <!-- Add the drop-down arrow icon -->
-          </label>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Constructors and Destructors
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
           <div class="hidden-text">
             <!-- Hidden content for the drop-down menu -->
             Constructors are special member functions that initialize objects when they are created. Destructors are used to release resources when objects are destroyed. Learn about different types of constructors and destructors in C++.

--- a/STL.html
+++ b/STL.html
@@ -23,47 +23,99 @@
     <section class="checklist">
       <h2>STL Basics</h2>
       <ul>
-        <li>
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="stl-basics">
-            <span class="checkmark"></span>
-            Containers (vector, list, set, map)
-          </label>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="stl-basics">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Containers (vector, list, set, map)
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
         </li>
-        <li>
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="stl-basics">
-            <span class="checkmark"></span>
-            Iterators
-          </label>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="stl-basics">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Iterators
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
         </li>
-        <li>
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="stl-basics">
-            <span class="checkmark"></span>
-            Algorithms (sort, find)
-          </label>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="stl-basics">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Algorithms (sort, find)
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
         </li>
-        <li>
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="stl-basics">
-            <span class="checkmark"></span>
-            Functors and Lambdas
-          </label>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="stl-basics">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Functors and Lambdas
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
         </li>
-        <li>
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="stl-basics">
-            <span class="checkmark"></span>
-            STL Functions (accumulate, transform)
-          </label>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="stl-basics">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                STL Functions (accumulate, transform)
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
         </li>
-        <li>
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="stl-basics">
-            <span class="checkmark"></span>
-            Custom Comparators and Hash Functions
-          </label>
+        <li class="checklist-item">
+          <div class="section-box">
+            <label class="section-box-label">
+              <input type="checkbox" class="checkbox" data-checklist="stl-basics">
+              <span class="checkmark"></span>
+            </label>
+          </div>
+          <div class="section-title">
+            <label class="section-title-label">
+              Custom Comparators and Hash Functions
+              <span class="dropdown-arrow"></span>
+            </label>
+          </div>
         </li>
       </ul>
     </section>

--- a/WebApp.html
+++ b/WebApp.html
@@ -31,26 +31,40 @@
       <h2>Web Application Fundamentals</h2>
       <ul>
         <li class="checklist-item">
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-            <span class="checkmark"></span>
-            What is a Web Application?
-            <span class="dropdown-arrow"></span>
-            <!-- Add the drop-down arrow icon -->
-          </label>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                What is a Web Application?
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
           <div class="hidden-text">
             <!-- Hidden content for the drop-down menu -->
             A web application is software that runs in your web browser. Businesses have to exchange information and deliver services remotely. They use web applications to connect with customers conveniently and securely.
           </div>
         </li>
         <li class="checklist-item">
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-            <span class="checkmark"></span>
-            Components of a Web Application
-            <span class="dropdown-arrow"></span>
-            <!-- Add the drop-down arrow icon -->
-          </label>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                Components of a Web Application
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
           <div class="hidden-text">
             <!-- Hidden content for the drop-down menu -->
             <ul>
@@ -63,13 +77,20 @@
         </div>
         </li>
         <li class="checklist-item">
-          <label>
-            <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-            <span class="checkmark"></span>
-            How does the Web Application work?
-            <span class="dropdown-arrow"></span>
-            <!-- Add the drop-down arrow icon -->
-          </label>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
+                How does the Web Application work?
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
           <div class="hidden-text">
             <!-- Hidden content for the drop-down menu -->
             Typically, the two sets of programs are the code in the browser that works with the user's inputs and the code in the server that deals with protocol requests, such as HTTPS.
@@ -77,66 +98,101 @@
           </div>
         </li>
         <li class="checklist-item">
-            <label>
-              <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-              <span class="checkmark"></span>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
                 Types of Web Application Architecture
-              <span class="dropdown-arrow"></span>
-              <!-- Add the drop-down arrow icon -->
-            </label>
-            <div class="hidden-text">
-              <!-- Hidden content for the drop-down menu -->
-              There are several types of web application architectures to consider, including monolithic, microservices, serverless, and three-tier. Each has its own set of benefits and drawbacks. A well-designed web application architecture is essential for the performance, scalability, and maintainability of a web application.
+                <span class="dropdown-arrow"></span>
+              </label>
             </div>
-          </li>
+          </div>
+          <div class="hidden-text">
+            <!-- Hidden content for the drop-down menu -->
+            There are several types of web application architectures to consider, including monolithic, microservices, serverless, and three-tier. Each has its own set of benefits and drawbacks. A well-designed web application architecture is essential for the performance, scalability, and maintainability of a web application.
+          </div>
+        </li>
         <li class="checklist-item">
-            <label>
-              <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-              <span class="checkmark"></span>
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
                 N-Tier Architecture
-              <span class="dropdown-arrow"></span>
-              <!-- Add the drop-down arrow icon -->
-            </label>
-            <div class="hidden-text">
-              <!-- Hidden content for the drop-down menu -->
-              N-tier data applications are data applications that are separated into multiple tiers. Also called "distributed applications" and "multitier applications", n-tier applications separate processing into discrete tiers that are distributed between the client and the server.
+                <span class="dropdown-arrow"></span>
+              </label>
             </div>
-          </li>
-          <li class="checklist-item">
-            <label>
-              <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-              <span class="checkmark"></span>
+          </div>
+          <div class="hidden-text">
+            <!-- Hidden content for the drop-down menu -->
+            N-tier data applications are data applications that are separated into multiple tiers. Also called "distributed applications" and "multitier applications", n-tier applications separate processing into discrete tiers that are distributed between the client and the server.
+          </div>
+        </li>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
                 Monolith vs Microservices
-              <span class="dropdown-arrow"></span>
-              <!-- Add the drop-down arrow icon -->
-            </label>
-            <div class="hidden-text">
-              <!-- Hidden content for the drop-down menu -->
-              A monolithic architecture refers to a software development pattern where all components of an application are combined into a single, tightly-coupled unit. This means the entire application, including its user interface, business logic, and data access layers, are developed and maintained within one cohesive codebase whereas a microservices architecture is a software development approach that divides an application into small, independent services. Each service focuses on a specific business function and communicates with other services through APIs or messaging systems. This architectural style promotes the creation of modular, scalable, and adaptable software.
+                <span class="dropdown-arrow"></span>
+              </label>
             </div>
-          </li>
-          <li class="checklist-item">
-            <label>
-              <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-              <span class="checkmark"></span>
+          </div>
+          <div class="hidden-text">
+            <!-- Hidden content for the drop-down menu -->
+            A monolithic architecture refers to a software development pattern where all components of an application are combined into a single, tightly-coupled unit. This means the entire application, including its user interface, business logic, and data access layers, are developed and maintained within one cohesive codebase whereas a microservices architecture is a software development approach that divides an application into small, independent services. Each service focuses on a specific business function and communicates with other services through APIs or messaging systems. This architectural style promotes the creation of modular, scalable, and adaptable software.
+          </div>
+        </li>
+        <li class="checklist-item">
+          <div class="section">
+            <div class="section-box">
+              <label class="section-box-label">
+                <input type="checkbox" class="checkbox" data-checklist="web-app">
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div class="section-title">
+              <label class="section-title-label">
                 Application Programming Interface(API)
-              <span class="dropdown-arrow"></span>
-              <!-- Add the drop-down arrow icon -->
-            </label>
-            <div class="hidden-text">
-              <!-- Hidden content for the drop-down menu -->
+                <span class="dropdown-arrow"></span>
+              </label>
+            </div>
+          </div>
+          <div class="hidden-text">
+            <!-- Hidden content for the drop-down menu -->
             APIs allow developers to sync data between multiple platforms and can facilitate communication among the various microservices in web applications. API integration is what does the work when, for example, you enter a new contact in Salesforce and it auto-populates to Marketo as well.
             APIs work by sharing data between applications, systems, and devices. This happens through a request and response cycle. A user initiates a request for data by interacting with an application. The request is sent to the API, which retrieves the data and returns it to the user.
-            </div>
+          </div>
           </li>
           <li class="checklist-item">
-            <label>
-              <input type="checkbox" class="checkbox" data-checklist="oop-cpp">
-              <span class="checkmark"></span>
-                What is MVC?
-              <span class="dropdown-arrow"></span>
-              <!-- Add the drop-down arrow icon -->
-            </label>
+            <div class="section">
+              <div class="section-box">
+                <label class="section-box-label">
+                  <input type="checkbox" class="checkbox" data-checklist="web-app">
+                  <span class="checkmark"></span>
+                </label>
+              </div>
+              <div class="section-title">
+                <label class="section-title-label">
+                  What is MVC?
+                  <span class="dropdown-arrow"></span>
+                </label>
+              </div>
+            </div>
             <div class="hidden-text">
               <!-- Hidden content for the drop-down menu -->
               Model–view–controller (MVC) is a software design pattern commonly used for developing user interfaces that divides the related program logic into three interconnected elements. This is done to separate internal representations of information from the ways information is presented to and accepted from the user.

--- a/script.js
+++ b/script.js
@@ -38,42 +38,71 @@ clickedGlowElements.forEach((element) => {
 });
 
 
-
+// Code no longer user since clicking the section title does this action
+// and section title encompasses the arrow
 // drop down arrow
 
 
-const dropdownArrows = document.querySelectorAll(".dropdown-arrow");
+// const dropdownArrows = document.querySelectorAll(".dropdown-arrow");
 
-dropdownArrows.forEach((arrow) => {
-  arrow.addEventListener("click", () => {
-    const listItem = arrow.closest("li");
-    const hiddenText = listItem.querySelector(".hidden-text");
-    hiddenText.classList.toggle("show");
-    arrow.classList.toggle("checked");
-  });
-});
-
-
+// dropdownArrows.forEach((arrow) => {
+//   arrow.addEventListener("click", () => {
+//     const listItem = arrow.closest("li");
+//     const hiddenText = listItem.querySelector(".hidden-text");
+//     hiddenText.classList.toggle("show");
+//     arrow.classList.toggle("checked");
+//   });
+// });
 
 
 
+
+// Code no longer user since clicking the section title does this action
+// and section title encompasses the arrow
 // shifting of checklist item when arrow is activated
 
-document.addEventListener("DOMContentLoaded", function () {
-  const dropdownArrows = document.querySelectorAll(".dropdown-arrow");
-  dropdownArrows.forEach(function (arrow) {
-    arrow.addEventListener("click", function () {
-      const checklistItem = arrow.closest(".checklist-item");
-      const hiddenText = checklistItem.querySelector(".hidden-text");
-      const checkbox = checklistItem.querySelector(".checkbox");
-      if (checkbox.checked) {
-        hiddenText.style.display = "block";
-        const hiddenTextHeight = hiddenText.clientHeight;
-        checklistItem.style.marginBottom = hiddenTextHeight + "px";
-      } else {
-        hiddenText.style.display = "none";
-        checklistItem.style.marginBottom = "0";
-      }
-    });
-  });
+// document.addEventListener("DOMContentLoaded", function () {
+//   const dropdownArrows = document.querySelectorAll(".dropdown-arrow");
+//   dropdownArrows.forEach(function (arrow) {
+//     arrow.addEventListener("click", function () {
+//       const checklistItem = arrow.closest(".checklist-item");
+//       const hiddenText = checklistItem.querySelector(".hidden-text");
+//       const checkbox = checklistItem.querySelector(".checkbox");
+//       if (checkbox.checked) {
+//         hiddenText.style.display = "block";
+//         const hiddenTextHeight = hiddenText.clientHeight;
+//         checklistItem.style.marginBottom = hiddenTextHeight + "px";
+//       } else {
+//         hiddenText.style.display = "none";
+//         checklistItem.style.marginBottom = "0";
+//       }
+//     });
+//   });
+// });
+
+// Add click event listener to checklist section titles
+const sectionTitles = document.querySelectorAll('.section-title-label');
+sectionTitles.forEach((label) => {
+  label.addEventListener('click', (e) => {
+    // prevent the label from triggering default behavior of toggling the checkbox
+    e.preventDefault();
+
+    // Expand section and change the arrow icon
+    const arrow = label.querySelector('[class*="dropdown-arrow"]');
+    const listItem = arrow.closest("li");
+    arrow.classList.toggle("checked");
+
+    const hiddenText = listItem.querySelector(".hidden-text");
+    hiddenText.classList.toggle("show");  // show hidden text
+
+    const checklistItem = arrow.closest(".checklist-item");
+    if (arrow.className === "dropdown-arrow checked") {
+      hiddenText.style.display = "block";
+      const hiddenTextHeight = hiddenText.clientHeight;
+      checklistItem.style.marginBottom = hiddenTextHeight + "px";
+    } else {
+      hiddenText.style.display = "none";
+      checklistItem.style.marginBottom = "0";
+    }
+  }, false);
 });

--- a/styles.css
+++ b/styles.css
@@ -794,3 +794,22 @@ input[type="checkbox"].checkbox:checked ~ .checkmark ~ .hidden-text {
 .checklist-item label {
   padding-top: 20px;
 }
+
+/* Used to line up the checkbox next to the section title since the checklist's
+checkbox and section title are now separate */
+.section {
+  overflow: hidden;
+}
+.section-box {
+  float: left;
+}
+.section-box-label {
+  height: 40px;
+}
+.section-title {
+  overflow: hidden;
+}
+.section-title-label {
+  overflow: hidden;
+  height: 40px;
+}


### PR DESCRIPTION
This enhancement Closes #24 

- Clicking checklist section title now does not toggle the checkbox, and instead expand/collapses the section
- To toggle the checkbox, click the checkbox (these two elements are no longer connected)

**Code changes:**

- in OOP.html, STL.html, WebApp.html and C++_Basics.html, separated the checklist section title label from the checkbox (checkbox is no longer a child of the title label). This allows clicking the title to expand and collapse the section without affecting the status of the checkbox. The checkbox can be still checked and unchecked, and is independent from the section title.
- in styles.css, added styling to the new div tags used to separate the section title and the checkbox so that these two line up well
- in script.js, added an event handler that gets triggered when user clicks the section title. The event expands/collapses the section and changes the arrow image. Commented out unnecessary/conflicting event handlers for the arrow, since clicking the section title also encompasses clicking the arrow.

Testing of enhancement:

![screen1](https://github.com/UjjwalSharma01/checklist/assets/98062538/2fffba0c-4326-4784-9b6f-83207713d184)
![screen2](https://github.com/UjjwalSharma01/checklist/assets/98062538/c1995ea4-a477-4fe3-b416-d5d7b4135267)
![screen3](https://github.com/UjjwalSharma01/checklist/assets/98062538/ddbc9198-f98f-4d89-a301-e919e1d234cd)

Please let me know if you wish for any changes/fixes!